### PR TITLE
Avanzata versione a 1.1.12. Aggiornato parent govpay-bom a 1.1.4 e go…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,29 @@
+2026-04-30  Giuliano Pintori <pintori@link.it>
+
+	* [Build]
+	Avanzata versione a 1.1.12.
+
+	* [API]
+	La lista dei tipi pendenza per il pagamento via portale
+	(GET /domini/{idDominio}/tipiPendenza) ora esclude i tipi con
+	pagAbilitato false o null. Il filtro è stato aggiunto nella
+	query JPQL findByDominioIdAndAbilitatoWithFormPortale.
+
+	* [Bug Fix]
+	In CreaPendenzaService, il tentativo di creare una pendenza per
+	un tipo con pagAbilitato non true ora restituisce HTTP 422
+	Unprocessable Entity (UnprocessableEntityException) invece di 400
+	Bad Request, conforme a RFC 9110 §15.5.21: la richiesta è
+	sintatticamente valida ma non processabile per vincoli di business.
+
+	* [Test]
+	Aggiornato CreaPendenzaServiceTest al nuovo tipo di eccezione.
+	Aggiornato PendenzeControllerIntegrationTest.testCreaPendenza_PagamentoNonAbilitato
+	per attendere HTTP 422 invece di 400.
+	Aggiunto in TipoVersamentoDominioRepositoryTest un test che
+	verifica l'esclusione dei tipi con pagAbilitato false o null
+	dal listing. Aggiornato AnagraficaServiceTest con pagAbilitato.
+
 2026-04-23  Giuliano Pintori <pintori@link.it>
 
 	* [Build]

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "CVE-2026-22747"
+reason = "False positive: CVE-2026-22747 affects only Spring Security 7.0.0-7.0.4"

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>org.gov4j.govpay</groupId>
         <artifactId>govpay-bom</artifactId>
-        <version>1.1.3-SNAPSHOT</version>
+        <version>1.1.4</version>
         <relativePath/>
     </parent>
 
     <groupId>it.govpay</groupId>
     <artifactId>govpay-portal-api</artifactId>
-    <version>1.1.11</version>
+    <version>1.1.12</version>
     <packaging>${packaging.type}</packaging>
 
     <name>GovPay Portal API</name>
@@ -26,7 +26,7 @@
         <swagger-annotations.version>2.2.25</swagger-annotations.version>
 
         <!-- govpay-common (not in BOM) -->
-        <govpay-common.version>1.0.0</govpay-common.version>
+        <govpay-common.version>1.1.2</govpay-common.version>
 
         <!-- mime-util (not in BOM) -->
         <mime-util.version>2.1.3</mime-util.version>
@@ -431,6 +431,7 @@
                     <failBuildOnCVSS>${owasp.plugin.failBuildOnCVSS}</failBuildOnCVSS>
                     <suppressionFiles>
                         <suppressionFile>${owasp.falsePositives.dir}/CVE-2018-14335.xml</suppressionFile>
+                        <suppressionFile>${owasp.falsePositives.dir}/CVE-2026-22747.xml</suppressionFile>
                     </suppressionFiles>
                     <nvdApiKey>${nvdApiKey}</nvdApiKey>
                     <ossIndexUsername>${ossIndexUsername}</ossIndexUsername>

--- a/src/main/java/it/govpay/portal/gde/service/GdeService.java
+++ b/src/main/java/it/govpay/portal/gde/service/GdeService.java
@@ -13,8 +13,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import it.govpay.common.client.service.ConnettoreService;
 import it.govpay.common.configurazione.ConfigurazioneKeys;
+import it.govpay.common.configurazione.model.GdeInterfaccia;
+import it.govpay.common.configurazione.model.Giornale;
 import it.govpay.common.gde.AbstractGdeService;
 import it.govpay.common.gde.GdeEventInfo;
+import it.govpay.gde.client.beans.ComponenteEvento;
 import it.govpay.gde.client.beans.NuovoEvento;
 import it.govpay.portal.gde.mapper.EventoPortalMapper;
 import jakarta.servlet.http.HttpServletRequest;
@@ -60,6 +63,24 @@ public class GdeService extends AbstractGdeService {
     protected NuovoEvento convertToGdeEvent(GdeEventInfo eventInfo) {
         throw new UnsupportedOperationException(
                 "GdeService usa sendEventAsync(NuovoEvento) direttamente, non il pattern GdeEventInfo");
+    }
+
+    @Override
+    protected GdeInterfaccia getConfigurazioneComponente(ComponenteEvento componente, Giornale giornale) {
+        if (componente == null || giornale == null) {
+            return null;
+        }
+        return switch (componente) {
+            case API_PAGOPA -> giornale.getApiPagoPA();
+            case API_ENTE -> giornale.getApiEnte();
+            case API_PAGAMENTO -> giornale.getApiPagamento();
+            case API_RAGIONERIA -> giornale.getApiRagioneria();
+            case API_BACKOFFICE -> giornale.getApiBackoffice();
+            case API_PENDENZE -> giornale.getApiPendenze();
+            case API_BACKEND_IO -> giornale.getApiBackendIO();
+            case API_MAGGIOLI_JPPA -> giornale.getApiMaggioliJPPA();
+            default -> null;
+        };
     }
 
     private void sendEventAsync(NuovoEvento nuovoEvento) {

--- a/src/main/java/it/govpay/portal/repository/TipoVersamentoDominioRepository.java
+++ b/src/main/java/it/govpay/portal/repository/TipoVersamentoDominioRepository.java
@@ -19,6 +19,7 @@ public interface TipoVersamentoDominioRepository extends JpaRepository<TipoVersa
 
     @Query("SELECT tvd FROM TipoVersamentoDominio tvd JOIN FETCH tvd.tipoVersamento tv " +
            "WHERE tvd.dominio.id = :idDominio AND tvd.abilitato = :abilitato " +
+           "AND tvd.pagAbilitato = true " +
            "AND ((tvd.pagFormDefinizione IS NOT NULL AND tvd.pagFormTipo IS NOT NULL) " +
            "  OR (tv.pagFormDefinizione IS NOT NULL AND tv.pagFormTipo IS NOT NULL " +
            "      AND tvd.pagFormDefinizione IS NULL AND tvd.pagFormTipo IS NULL)) " +

--- a/src/main/java/it/govpay/portal/service/CreaPendenzaService.java
+++ b/src/main/java/it/govpay/portal/service/CreaPendenzaService.java
@@ -102,7 +102,7 @@ public class CreaPendenzaService {
 
         // 2. Verifica che il pagamento spontaneo sia abilitato
         if (!Boolean.TRUE.equals(tipoVersamentoDominio.getPagAbilitato())) {
-            throw new BadRequestException(
+            throw new UnprocessableEntityException(
                     "Pagamento spontaneo non abilitato per tipo pendenza " + idTipoPendenza);
         }
 

--- a/src/main/resources/owasp/falsePositives/CVE-2026-22747.xml
+++ b/src/main/resources/owasp/falsePositives/CVE-2026-22747.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes>False positive: CVE-2026-22747 affects only Spring Security 7.0.0-7.0.4</notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.security/.*@6\.5\.10$</packageUrl>
+        <cve>CVE-2026-22747</cve>
+    </suppress>
+</suppressions>

--- a/src/test/java/it/govpay/portal/controller/PendenzeControllerIntegrationTest.java
+++ b/src/test/java/it/govpay/portal/controller/PendenzeControllerIntegrationTest.java
@@ -265,7 +265,7 @@ class PendenzeControllerIntegrationTest {
     }
 
     @Test
-    @DisplayName("POST pendenze - Pagamento non abilitato restituisce 400")
+    @DisplayName("POST pendenze - Pagamento non abilitato restituisce 422")
     void testCreaPendenza_PagamentoNonAbilitato() throws Exception {
         // Given
         tipoVersamentoDominio.setPagAbilitato(false);
@@ -286,7 +286,7 @@ class PendenzeControllerIntegrationTest {
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isUnprocessableEntity());
 
         // Verifica che NON sia stata fatta chiamata a GovPay
         verify(pendenzeApi, never()).addPendenza(anyString(), anyString(), anyBoolean(), any(), any());

--- a/src/test/java/it/govpay/portal/repository/TipoVersamentoDominioRepositoryTest.java
+++ b/src/test/java/it/govpay/portal/repository/TipoVersamentoDominioRepositoryTest.java
@@ -70,6 +70,7 @@ class TipoVersamentoDominioRepositoryTest {
                 .dominio(dominio)
                 .tipoVersamento(tvZzz)
                 .abilitato(true)
+                .pagAbilitato(true)
                 .pagFormTipo("formTipo")
                 .pagFormDefinizione("formDef")
                 .build();
@@ -79,6 +80,7 @@ class TipoVersamentoDominioRepositoryTest {
                 .dominio(dominio)
                 .tipoVersamento(tvAaa)
                 .abilitato(true)
+                .pagAbilitato(true)
                 .pagFormTipo("formTipo")
                 .pagFormDefinizione("formDef")
                 .build();
@@ -88,6 +90,7 @@ class TipoVersamentoDominioRepositoryTest {
                 .dominio(dominio)
                 .tipoVersamento(tvMmm)
                 .abilitato(true)
+                .pagAbilitato(true)
                 .pagFormTipo("formTipo")
                 .pagFormDefinizione("formDef")
                 .build();
@@ -101,5 +104,69 @@ class TipoVersamentoDominioRepositoryTest {
         assertEquals("Aaa - Primo tipo", result.get(0).getTipoVersamento().getDescrizione());
         assertEquals("Mmm - Tipo intermedio", result.get(1).getTipoVersamento().getDescrizione());
         assertEquals("Zzz - Ultimo tipo", result.get(2).getTipoVersamento().getDescrizione());
+    }
+
+    @Test
+    @DisplayName("findByDominioIdAndAbilitatoWithFormPortale dovrebbe escludere tipi con pagAbilitato false o null")
+    void shouldExcludeTipiWithPagAbilitatoFalseOrNull() {
+        TipoVersamento tvAbilitato = TipoVersamento.builder()
+                .codTipoVersamento("ABILITATO")
+                .descrizione("Tipo abilitato")
+                .pagFormTipo("formTipo")
+                .pagFormDefinizione("formDef")
+                .build();
+        entityManager.persist(tvAbilitato);
+
+        TipoVersamento tvDisabilitato = TipoVersamento.builder()
+                .codTipoVersamento("DISABILITATO")
+                .descrizione("Tipo disabilitato")
+                .pagFormTipo("formTipo")
+                .pagFormDefinizione("formDef")
+                .build();
+        entityManager.persist(tvDisabilitato);
+
+        TipoVersamento tvNull = TipoVersamento.builder()
+                .codTipoVersamento("NULL")
+                .descrizione("Tipo con pagAbilitato null")
+                .pagFormTipo("formTipo")
+                .pagFormDefinizione("formDef")
+                .build();
+        entityManager.persist(tvNull);
+
+        TipoVersamentoDominio tvdAbilitato = TipoVersamentoDominio.builder()
+                .dominio(dominio)
+                .tipoVersamento(tvAbilitato)
+                .abilitato(true)
+                .pagAbilitato(true)
+                .pagFormTipo("formTipo")
+                .pagFormDefinizione("formDef")
+                .build();
+        entityManager.persist(tvdAbilitato);
+
+        TipoVersamentoDominio tvdDisabilitato = TipoVersamentoDominio.builder()
+                .dominio(dominio)
+                .tipoVersamento(tvDisabilitato)
+                .abilitato(true)
+                .pagAbilitato(false)
+                .pagFormTipo("formTipo")
+                .pagFormDefinizione("formDef")
+                .build();
+        entityManager.persist(tvdDisabilitato);
+
+        TipoVersamentoDominio tvdNull = TipoVersamentoDominio.builder()
+                .dominio(dominio)
+                .tipoVersamento(tvNull)
+                .abilitato(true)
+                .pagFormTipo("formTipo")
+                .pagFormDefinizione("formDef")
+                .build();
+        entityManager.persist(tvdNull);
+
+        entityManager.flush();
+
+        List<TipoVersamentoDominio> result = repository.findByDominioIdAndAbilitatoWithFormPortale(dominio.getId(), true);
+
+        assertEquals(1, result.size());
+        assertEquals("Tipo abilitato", result.get(0).getTipoVersamento().getDescrizione());
     }
 }

--- a/src/test/java/it/govpay/portal/service/AnagraficaServiceTest.java
+++ b/src/test/java/it/govpay/portal/service/AnagraficaServiceTest.java
@@ -214,6 +214,7 @@ class AnagraficaServiceTest {
                     .dominio(dominioEntity)
                     .tipoVersamento(tipoVersamento)
                     .abilitato(true)
+                    .pagAbilitato(true)
                     .pagFormDefinizione("formDef")
                     .pagFormTipo("formTipo")
                     .build();

--- a/src/test/java/it/govpay/portal/service/CreaPendenzaServiceTest.java
+++ b/src/test/java/it/govpay/portal/service/CreaPendenzaServiceTest.java
@@ -29,7 +29,6 @@ import it.govpay.portal.config.SpidUserDetails;
 import it.govpay.portal.entity.Dominio;
 import it.govpay.portal.entity.TipoVersamento;
 import it.govpay.portal.entity.TipoVersamentoDominio;
-import it.govpay.portal.exception.BadRequestException;
 import it.govpay.portal.exception.NotFoundException;
 import it.govpay.portal.exception.UnprocessableEntityException;
 import it.govpay.portal.exception.ValidationException;
@@ -177,7 +176,7 @@ class CreaPendenzaServiceTest {
                 .thenReturn(Optional.of(tipoVersamentoDominio));
 
         // When/Then
-        assertThrows(BadRequestException.class, () ->
+        assertThrows(UnprocessableEntityException.class, () ->
                 creaPendenzaService.creaPendenza(
                         idDominio,
                         idTipoPendenza,


### PR DESCRIPTION
…vpay-common a 1.1.2; allineato GdeService al nuovo metodo astratto AbstractGdeService.getConfigurazioneComponente(ComponenteEvento, Giornale). Aggiunte suppression CVE-2026-22747 (false positive su Spring Security 6.5.10) per OWASP Dependency-Check e OSV-Scanner. Filtrati i tipi pendenza non abilitati al pagamento via portale (pagAbilitato true) e modificato CreaPendenzaService per restituire 422 Unprocessable Entity al posto di 400 Bad Request quando pagAbilitato non è true. Aggiornati test correlati.